### PR TITLE
Wrapper script to allow mailing through local user's account directly

### DIFF
--- a/example.config
+++ b/example.config
@@ -1,15 +1,27 @@
 # Whom to email this too
 sendto="user@domain.com"
+sendfrom="taskuser@taskdomain.com"
 
 # Which report to send (blank for default as set in .taskrc)
 # other reports can be setup in the .taskrc file
 report=""
 
 # Directory to find support files
-inc="/home/user/scripts/taskwarrior-notifications"
+inc="$HOME/scripts/taskwarrior-notifications"
 tmp_email="/tmp/task_email.txt"
 scripts="$inc/scripts"
-mail_prog="/usr/sbin/ssmtp"
+
+# sending using MTA
+#mail_prog="/usr/sbin/ssmtp"
+
+# direct local delivery to yourself
+# using procmail
+mail_prog=procmailsend
+
+procmailsend() {
+	shift
+	/usr/bin/procmail
+}
 
 # Where to find the templates to use for HTML email
 templates="$inc/templates"


### PR DESCRIPTION
Simply ignoring the send-to address. 
I guess the function could be called anything and should be transferred to a special helper-scripts file as soon as a second function is added, but it solved the problem I had and might be useful for others.

Further I habitually inserted a sendfrom parameter and generalised the home-directory. I just couldn't help it, it happened while reading the config, but it is somewhat useful.