### PR TITLE
Fix task default export output for the newest version

### DIFF
--- a/task-email.sh
+++ b/task-email.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #email myself info about upcoming tasks in a pretty HTML format
 # Requires ssmtp
@@ -13,6 +13,9 @@ else
   echo "No configuration file found. Maybe you need to copy and edit the example.config file to config."
   exit 1
 fi
+
+# taskrc defaults
+taskrc="rc.json.array=off rc.verbose=nothing"
 
 # Format time string
 date=`date '+%d/%m/%Y'` #07/09/2012
@@ -41,32 +44,32 @@ echo "<h1>Task Info: $date</h1>" >> $tmp_email
 
 # Overdue
 echo "<h2>Overdue</h2>" >> $tmp_email
-echo `task "due.before:today and status:pending" export | $scripts/export-html.py` >> $tmp_email
+echo `task "due.before:today and status:pending" export ${taskrc} | $scripts/export-html.py` >> $tmp_email
 
 if [[ $(date +%u) -lt 6 ]] ; then # Weekday
 
 # Today
 echo "<h2>Today</h2>" >> $tmp_email
-echo `task "due:today and status:pending" export | $scripts/export-html.py` >> $tmp_email
+echo `task "due:today and status:pending" export ${taskrc} | $scripts/export-html.py` >> $tmp_email
 # This Week (but not today)
 echo "<h2>This Week</h2>" >> $tmp_email
-echo `task "due.after:today and (due.before:$eow or due:$eow) and status:pending" export | $scripts/export-html.py` >> $tmp_email
+echo `task "due.after:today and (due.before:$eow or due:$eow) and status:pending" export ${taskrc} | $scripts/export-html.py` >> $tmp_email
 
 else
 
 # This Weekend
 echo "<h2>This Weekend</h2>" >> $tmp_email
 if [[ $(date +%u) -eq 6 ]] ; then # Saturday 
-  echo `task "(due:today or due:tomorrow) and status:pending" export | $scripts/export-html.py` >> $tmp_email
+  echo `task "(due:today or due:tomorrow) and status:pending" export ${taskrc} | $scripts/export-html.py` >> $tmp_email
 else # Sunday
-  echo `task "(due:yesterday or due:today) and status:pending" export | $scripts/export-html.py` >> $tmp_email
+  echo `task "(due:yesterday or due:today) and status:pending" export ${taskrc} | $scripts/export-html.py` >> $tmp_email
 fi
 
 fi
 
 # Next Week
 echo "<h2>Next Week</h2>" >> $tmp_email
-echo `task "due.after:$eow and (due.before:$eonw or due:$eonw) and status:pending" export | $scripts/export-html.py` >> $tmp_email
+echo `task "due.after:$eow and (due.before:$eonw or due:$eonw) and status:pending" export ${taskrc} | $scripts/export-html.py` >> $tmp_email
 
 cat $templates/html_email_foot.template >> $tmp_email
 


### PR DESCRIPTION
- The latest version export the JSON data as array (need to be disabled for the python script): `rc.json.array=off`
- Warning output should be ignored: `rc.verbose=nothing`
- `bash` maybe on a different location